### PR TITLE
feat: Add Comm Coordinator link and fix npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "./node_modules/.bin/next dev --turbopack",
-    "build": "./node_modules/.bin/next build",
-    "start": "./node_modules/.bin/next start",
-    "lint": "./node_modules/.bin/eslint",
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint",
     "prebuild": "npm run generate-manifest",
     "generate-manifest": "node scripts/generate-manifest.js"
   },


### PR DESCRIPTION
- Adds a new entry to `public/pages.manifest.json` for the 'Comm Coordinator Workstation' sample, making it appear on the main dashboard.
- Updates `dev`, `build`, `start`, and `lint` scripts in `package.json` to be cross-platform compatible by removing the explicit `./node_modules/.bin/` path.