### PR TITLE
feat: Add Comm Coordinator sample and resolve related issues

### DIFF
--- a/src/components/sample-viewer.tsx
+++ b/src/components/sample-viewer.tsx
@@ -12,6 +12,7 @@ const components: Record<SampleSlug, React.ComponentType> = {
   'rokaf-mcrc-east-asia': dynamic(() => import('@/samples/rokaf-mcrc-east-asia.tsx')),
   'rokaf-radar-controller-workstation': dynamic(() => import('@/samples/rokaf-radar-controller-workstation.tsx')),
   'rokaf-sector-ke14-operations': dynamic(() => import('@/samples/rokaf-sector-ke14-operations.tsx')),
+  'comm-coordinator-workstation': dynamic(() => import('@/samples/comm-coordinator-workstation.tsx')),
 };
 
 export function SampleViewer({ slug }: { slug: SampleSlug }) {


### PR DESCRIPTION
This commit fully integrates the new 'Comm Coordinator Workstation' sample page and includes several related fixes identified during the process.

- **Feature**: Adds the `comm-coordinator-workstation` to `public/pages.manifest.json` to make it appear on the root dashboard.
- **Fix**: Adds the corresponding slug to the `sampleSlugs` array in `src/lib/types.ts`, which is required for type safety and for Next.js to statically generate the page.
- **Fix**: Adds the new component to the dynamic import map in `src/components/sample-viewer.tsx`.
- **Fix**: Resolves a runtime error in Next.js v15 by making the dynamic route component `src/app/samples/[slug]/page.tsx` an `async` function.
- **Chore**: Updates npm scripts (`dev`, `build`, `start`, `lint`) in `package.json` to be cross-platform compatible by removing hardcoded paths.