### PR TITLE
fix: 비어있는 샘플 페이지의 렌더링 로직 복구

### DIFF
--- a/src/samples/rokaf-mcrc-advanced-v2.tsx
+++ b/src/samples/rokaf-mcrc-advanced-v2.tsx
@@ -253,8 +253,84 @@ const ROKAFMCRCAdvanced = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-green-300 font-mono">
-      {/* ... rest of the component ... */}
+    <div className="min-h-screen bg-black text-green-300 font-mono flex flex-col">
+      {/* Header */}
+      <header className="bg-gray-900/50 border-b border-green-900/50 p-2 flex justify-between items-center text-xs backdrop-blur-sm">
+        <div className="flex items-center space-x-4">
+          <h1 className="font-bold text-lg text-cyan-400">ROKAF MCRC V2</h1>
+          <div>TIME: {currentTime.toISOString().substr(11, 8)}Z</div>
+        </div>
+        <div className="flex items-center space-x-4">
+          <div>FPCON: <span className="text-yellow-400 font-bold">{threatLevel}</span></div>
+          <div>ALERT: <span className="text-red-500 font-bold">{alertLevel}</span></div>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Settings className="w-4 h-4" />
+          <Radio className="w-4 h-4" />
+          <CloudRain className="w-4 h-4" />
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Main Map Area */}
+        <main className="flex-1 bg-gray-800/80 relative overflow-hidden" style={{
+            background: 'radial-gradient(circle, #001a00 1px, transparent 1px), repeating-linear-gradient(0deg, transparent, transparent 19px, #002a00 20px), repeating-linear-gradient(90deg, transparent, transparent 19px, #002a00 20px)',
+            backgroundSize: '20px 20px, 100% 20px, 20px 100%',
+        }}>
+            {activeTracks.map(renderTrack)}
+            {groundThreats.map(renderGroundThreat)}
+        </main>
+
+        {/* Right Sidebar */}
+        <aside className="w-80 bg-gray-900/70 border-l border-green-900/50 flex flex-col backdrop-blur-sm">
+          {/* Grid Sectors */}
+          <div className="p-2 border-b border-green-900/50">
+            <h2 className="text-center font-bold text-cyan-400">GRID SECTORS</h2>
+          </div>
+          <div className="flex-1 overflow-y-auto text-xs">
+            {gridSectors.map(sector => (
+              <div key={sector.id} className={`p-2 border-b border-gray-800/50 flex justify-between items-center cursor-pointer hover:bg-green-900/30 ${selectedGrid === sector.id ? 'bg-green-800/50' : ''}`} onClick={() => setSelectedGrid(sector.id)}>
+                <div>
+                  <span className="font-bold text-cyan-300">{sector.id}</span>
+                  <div className="text-[10px] text-gray-400">{sector.controller}</div>
+                </div>
+                <div className="text-right">
+                  <div className={`font-bold text-${sector.color}-400`}>{sector.threat}</div>
+                  <div className="text-[10px]">{sector.tracks} Tracks</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Selected Track Info */}
+          <div className="p-2 border-t border-green-900/50">
+            <h2 className="text-center font-bold text-cyan-400">TRACK DETAILS</h2>
+          </div>
+          <div className="p-3 text-xs space-y-1 h-48 overflow-y-auto">
+            {selectedTrack ? (
+              <>
+                <div><span className="font-bold text-gray-400">ID:</span> {selectedTrack.id}</div>
+                <div><span className="font-bold text-gray-400">TYPE:</span> {selectedTrack.type}</div>
+                <div><span className="font-bold text-gray-400">ALT:</span> {selectedTrack.altitude} ft</div>
+                <div><span className="font-bold text-gray-400">SPD:</span> {selectedTrack.speed} kts</div>
+                <div><span className="font-bold text-gray-400">STATUS:</span> <span className={`font-bold text-${selectedTrack.status === 'FRIENDLY' ? 'green' : selectedTrack.status === 'UNKNOWN' ? 'yellow' : 'red'}-400`}>{selectedTrack.status}</span></div>
+                <div><span className="font-bold text-gray-400">PILOT:</span> {selectedTrack.pilot}</div>
+              </>
+            ) : (
+              <div className="text-center text-gray-500 pt-8">No Track Selected</div>
+            )}
+          </div>
+        </aside>
+      </div>
+
+      {/* Footer */}
+      <footer className="bg-gray-900/50 border-t border-green-900/50 p-2 flex justify-center items-center space-x-4 text-xs backdrop-blur-sm">
+        <button onClick={() => setRadarMode(radarMode === 'WIDE_AREA' ? 'SECTOR_SCAN' : 'WIDE_AREA')} className="px-2 py-1 bg-gray-800 hover:bg-gray-700 border border-green-800 rounded">RADAR: {radarMode}</button>
+        <button onClick={() => setShowTrails(!showTrails)} className={`px-2 py-1 bg-gray-800 hover:bg-gray-700 border border-green-800 rounded ${showTrails ? 'text-cyan-400' : ''}`}>TRAILS</button>
+        <button onClick={() => setAlertLevel('HIGH')} className="px-2 py-1 bg-yellow-800/50 hover:bg-yellow-700/50 border border-yellow-800 rounded text-yellow-300">ALERT</button>
+        <button onClick={() => setAlertLevel('CRITICAL')} className="px-2 py-1 bg-red-800/50 hover:bg-red-700/50 border border-red-800 rounded text-red-300">SCRAMBLE</button>
+      </footer>
     </div>
   );
 };

--- a/src/samples/rokaf-sector-ke14-operations.tsx
+++ b/src/samples/rokaf-sector-ke14-operations.tsx
@@ -340,8 +340,65 @@ const ROKAFSectorKE14Detail = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-green-300 font-mono">
-      {/* ... rest of component ... */}
+    <div className="min-h-screen bg-gray-900 text-green-300 font-mono flex flex-col">
+      {/* Header */}
+      <header className="bg-gray-800/80 border-b border-green-800/50 p-3 flex justify-between items-center text-sm backdrop-blur-sm">
+        <div className="flex items-center space-x-4">
+          <h1 className="font-bold text-xl text-cyan-400">SECTOR KE-14 OPERATIONS</h1>
+          <div className="text-xs">TIME: {currentTime.toLocaleTimeString('en-US', { hour12: false })}Z</div>
+        </div>
+        <div className={`border-2 p-2 rounded-lg ${
+          alertStatus === 'GREEN' ? 'border-green-500' :
+          alertStatus === 'YELLOW' ? 'border-yellow-500' : 'border-red-500'
+        }`}>
+          <div className="flex items-center space-x-2">
+            <AlertTriangle className={`w-6 h-6 ${
+              alertStatus === 'GREEN' ? 'text-green-500' :
+              alertStatus === 'YELLOW' ? 'text-yellow-500' : 'text-red-500'
+            }`} />
+            <span className="font-bold text-lg">ALERT STATUS: {alertStatus}</span>
+          </div>
+        </div>
+        <div className="flex items-center space-x-3">
+          <Settings className="w-5 h-5 cursor-pointer hover:text-cyan-300" />
+          <Users className="w-5 h-5 cursor-pointer hover:text-cyan-300" />
+          <BarChart3 className="w-5 h-5 cursor-pointer hover:text-cyan-300" />
+        </div>
+      </header>
+
+      {/* Main Content Area */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Operator Stations */}
+        <aside className="w-1/3 bg-gray-800/50 border-r border-green-800/50 p-3 overflow-y-auto">
+          <h2 className="text-lg font-bold text-center text-cyan-400 mb-3">OPERATOR STATIONS</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {operatorStations.map(renderOperatorStation)}
+          </div>
+        </aside>
+
+        {/* Tactical Map */}
+        <main className="w-2/3 bg-black/50 relative" style={{
+          background: 'radial-gradient(circle, #001a00 1px, transparent 1px), repeating-linear-gradient(0deg, transparent, transparent 24px, #002a00 25px), repeating-linear-gradient(90deg, transparent, transparent 24px, #002a00 25px)',
+          backgroundSize: '25px 25px, 100% 25px, 25px 100%',
+        }}>
+          {sectorTracks.map(renderTrack)}
+        </main>
+      </div>
+
+      {/* Footer / Comms Log */}
+      <footer className="h-40 bg-gray-800/80 border-t border-green-800/50 p-3 flex flex-col backdrop-blur-sm">
+        <h2 className="text-lg font-bold text-cyan-400 mb-2 flex items-center"><MessageSquare className="w-5 h-5 mr-2" />COMMS LOG</h2>
+        <div className="flex-1 overflow-y-auto text-xs space-y-1">
+          {commLog.map((log, index) => (
+            <div key={index} className="flex space-x-2 items-start">
+              <span className="text-gray-500">{log.time.toLocaleTimeString('en-US', { hour12: false })}</span>
+              <span className={`font-bold w-24 ${log.priority === 'URGENT' ? 'text-red-500' : log.priority === 'PRIORITY' ? 'text-yellow-500' : 'text-green-500'}`}>{log.from} &gt; {log.to}</span>
+              <p className="flex-1 text-gray-300">{log.message}</p>
+              <span className="text-purple-400 text-[10px]">({log.channel})</span>
+            </div>
+          ))}
+        </div>
+      </footer>
     </div>
   );
 };


### PR DESCRIPTION
사용자로부터 2개의 샘플 페이지(`rokaf-mcrc-advanced-v2`, `rokaf-sector-ke14-operations`)가 비어 있다는 보고를 받아 수정했습니다.

두 컴포넌트 파일 모두 렌더링할 JSX 코드가 주석 처리되어 비어있는 상태였습니다. 각 파일에 정의된 데이터와 함수를 사용하여 완전한 UI를 렌더링하도록 JSX 코드를 복구하고 추가했습니다.

이 수정으로 인해 페이지가 정상적으로 표시되고, 빌드 시 발생하던 '사용하지 않는 변수' 경고가 대부분 해결되었습니다.