### PR TITLE
feat: DCRC 보고서 페이지 개편 및 전체 샘플 페이지 복원

### DIFF
--- a/src/samples/rokaf-mcrc-advanced-v2.tsx
+++ b/src/samples/rokaf-mcrc-advanced-v2.tsx
@@ -1,9 +1,15 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { 
-  Radar, Target, Plane, Activity, Settings, Flame, Zap, Skull, Crosshair, Radio, CloudRain
+  Shield, Target, Navigation, Radar, Radio, Satellite,
+  AlertTriangle, CheckCircle, XCircle, Clock, Battery,
+  Eye, Camera, Crosshair, Map, Globe, Zap, Activity,
+  Users, Settings, Bell, Download, Upload, RefreshCw,
+  Plane, Wind, Thermometer, CloudRain, Sun, Moon,
+  Lock, Unlock, Key, FileText, Headphones, Mic,
+  Flame, Skull, Minus, Plus, Maximize, Minimize
 } from 'lucide-react';
 
-type TrackStatus = 'FRIENDLY' | 'UNKNOWN' | 'HOSTILE';
+type TrackStatus = 'FRIENDLY' | 'UNKNOWN' | 'HOSTILE' | 'CIVIL';
 type ThreatStatus = 'HIGH' | 'MEDIUM' | 'LOW';
 
 interface Track {
@@ -17,10 +23,10 @@ interface Track {
   altitude: number;
   status: TrackStatus;
   controller: string;
-  fuel?: number | string;
-  weapons?: string;
-  pilot?: string;
-  eta?: string;
+  fuel: number | string;
+  weapons: string;
+  pilot: string;
+  eta: string;
 }
 
 interface GroundThreat {
@@ -36,22 +42,10 @@ const ROKAFMCRCAdvanced = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
   const [selectedGrid, setSelectedGrid] = useState('KE-12');
   const [selectedTrack, setSelectedTrack] = useState<Track | null>(null);
-  const [selectedThreat, setSelectedThreat] = useState<GroundThreat | null>(null);
-  const [threatLevel] = useState('FPCON-BRAVO');
+  const [threatLevel, setThreatLevel] = useState('FPCON-BRAVO');
   const [radarMode, setRadarMode] = useState('WIDE_AREA');
   const [showTrails, setShowTrails] = useState(true);
   const [alertLevel, setAlertLevel] = useState('NORMAL');
-  const [filters, setFilters] = useState({
-    friendly: true,
-    unknown: true,
-    hostile: true,
-    ground: true,
-  });
-
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, checked } = event.target;
-    setFilters(prev => ({ ...prev, [name]: checked }));
-  };
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -60,7 +54,8 @@ const ROKAFMCRCAdvanced = () => {
     return () => clearInterval(timer);
   }, []);
 
-  const gridSectors = [
+  // 확장된 동아시아 격자 체계 (15개 구역)
+  const gridSectors: {id: string, controller: string, tracks: number, threat: string, activity: string, color: string}[] = [
     { id: 'IE-06', controller: 'LT Col Park S.H.', tracks: 8, threat: 'LOW', activity: 'NORMAL', color: 'green' },
     { id: 'IE-10', controller: 'MAJ Kim D.W.', tracks: 15, threat: 'LOW', activity: 'PATROL', color: 'green' },
     { id: 'IE-14', controller: 'CPT Lee J.S.', tracks: 12, threat: 'MEDIUM', activity: 'ALERT', color: 'yellow' },
@@ -78,19 +73,55 @@ const ROKAFMCRCAdvanced = () => {
     { id: 'ME-14', controller: 'LT Col Lim J.W.', tracks: 17, threat: 'LOW', activity: 'NORMAL', color: 'green' }
   ];
 
+  // 확장된 항공기/드론/위협 추적 시스템
   const activeTracks: Track[] = [
+    // 아군 전투기
     { 
       id: 'KAF001', callsign: 'VIPER-01', type: 'F-16C', mission: 'CAP',
       position: { x: 420, y: 180 }, vector: { dx: -8, dy: 6 },
       speed: 420, altitude: 28000, status: 'FRIENDLY', controller: 'KE-10',
       fuel: 68, weapons: 'AIM-120C x4', pilot: 'CPT Kim S.H.', eta: '15:30Z'
     },
+    {
+      id: 'KAF002', callsign: 'VIPER-02', type: 'F-16C', mission: 'CAP',
+      position: { x: 440, y: 200 }, vector: { dx: -6, dy: 8 },
+      speed: 415, altitude: 27000, status: 'FRIENDLY', controller: 'KE-10',
+      fuel: 72, weapons: 'AIM-120C x4', pilot: 'CPT Lee J.W.', eta: '15:35Z'
+    },
+    // 차세대 전투기
+    {
+      id: 'KAF003', callsign: 'STEALTH-01', type: 'F-35A', mission: 'DCA',
+      position: { x: 380, y: 160 }, vector: { dx: 12, dy: -4 },
+      speed: 480, altitude: 35000, status: 'FRIENDLY', controller: 'JE-10',
+      fuel: 85, weapons: 'AIM-120C x2, AIM-9X x2', pilot: 'MAJ Park H.S.', eta: '16:00Z'
+    },
+    // 드론 편대
     { 
       id: 'UAV001', callsign: 'HAWK-01', type: 'MQ-9 Reaper', mission: 'ISR',
       position: { x: 340, y: 200 }, vector: { dx: 3, dy: -2 },
       speed: 135, altitude: 18000, status: 'FRIENDLY', controller: 'JE-14',
       fuel: 92, weapons: 'Hellfire x2', pilot: 'SGT Kim M.J.', eta: '18:45Z'
     },
+    {
+      id: 'UAV002', callsign: 'GHOST-02', type: 'KUS-FS', mission: 'SEAD',
+      position: { x: 320, y: 220 }, vector: { dx: 5, dy: 1 },
+      speed: 180, altitude: 15000, status: 'FRIENDLY', controller: 'JE-14',
+      fuel: 78, weapons: 'AGM-88 x4', pilot: 'SGT Park D.K.', eta: '17:20Z'
+    },
+    // 민간기
+    {
+      id: 'CIV001', callsign: 'KAL-123', type: 'B777-300', mission: 'CIVIL',
+      position: { x: 450, y: 250 }, vector: { dx: -12, dy: 3 },
+      speed: 485, altitude: 37000, status: 'FRIENDLY', controller: 'KE-14',
+      fuel: 65, weapons: 'NONE', pilot: 'CPT civilian', eta: '14:55Z'
+    },
+    {
+      id: 'CIV002', callsign: 'AAR-456', type: 'A320', mission: 'CIVIL',
+      position: { x: 520, y: 180 }, vector: { dx: -15, dy: -2 },
+      speed: 460, altitude: 39000, status: 'FRIENDLY', controller: 'KE-14',
+      fuel: 58, weapons: 'NONE', pilot: 'CPT civilian', eta: '15:15Z'
+    },
+    // 미식별/적 위협
     { 
       id: 'UNK001', callsign: 'UNKNOWN-1', type: '?', mission: '?',
       position: { x: 280, y: 160 }, vector: { dx: 18, dy: 12 },
@@ -103,8 +134,23 @@ const ROKAFMCRCAdvanced = () => {
       speed: 620, altitude: 35000, status: 'HOSTILE', controller: 'JE-06',
       fuel: '?', weapons: 'UNKNOWN', pilot: '?', eta: '?'
     },
+    // 정찰기
+    {
+      id: 'REC001', callsign: 'SENTRY-01', type: 'E-737', mission: 'AEW',
+      position: { x: 400, y: 120 }, vector: { dx: -3, dy: 8 },
+      speed: 280, altitude: 30000, status: 'FRIENDLY', controller: 'IE-10',
+      fuel: 88, weapons: 'NONE', pilot: 'MAJ Choi S.K.', eta: '19:30Z'
+    },
+    // 공중급유기
+    {
+      id: 'TKR001', callsign: 'SHELL-01', type: 'KC-330', mission: 'AAR',
+      position: { x: 360, y: 280 }, vector: { dx: 2, dy: -6 },
+      speed: 240, altitude: 25000, status: 'FRIENDLY', controller: 'LE-10',
+      fuel: 95, weapons: 'NONE', pilot: 'LT Col Kim H.W.', eta: '16:45Z'
+    }
   ];
 
+  // 지상 위협 요소
   const groundThreats: GroundThreat[] = [
     { id: 'SAM001', type: 'SA-21 GROWLER', position: { x: 230, y: 180 }, range: 400, status: 'ACTIVE', threat: 'HIGH' },
     { id: 'SAM002', type: 'SA-20 GARGOYLE', position: { x: 200, y: 200 }, range: 300, status: 'ACTIVE', threat: 'MEDIUM' },
@@ -112,26 +158,19 @@ const ROKAFMCRCAdvanced = () => {
     { id: 'AAA001', type: 'ZSU-23-4', position: { x: 260, y: 220 }, range: 25, status: 'STANDBY', threat: 'LOW' }
   ];
 
-  const filteredTracks = activeTracks.filter(track => {
-    if (track.status === 'FRIENDLY' && !filters.friendly) return false;
-    if (track.status === 'UNKNOWN' && !filters.unknown) return false;
-    if (track.status === 'HOSTILE' && !filters.hostile) return false;
-    return true;
-  });
-
-  const filteredThreats = filters.ground ? groundThreats : [];
-
   const renderTrack = (track: Track) => {
-    const colors: Record<TrackStatus, string> = {
+    const colors = {
       'FRIENDLY': 'text-green-400 bg-green-900/30 border-green-400',
       'UNKNOWN': 'text-yellow-400 bg-yellow-900/30 border-yellow-400',
-      'HOSTILE': 'text-red-400 bg-red-900/30 border-red-400'
+      'HOSTILE': 'text-red-400 bg-red-900/30 border-red-400',
+      'CIVIL': 'text-blue-400 bg-blue-900/30 border-blue-400'
     };
 
-    const shapes: Record<TrackStatus, string> = {
+    const shapes = {
       'FRIENDLY': 'rounded-full',
       'UNKNOWN': 'rounded-sm',
-      'HOSTILE': 'rounded-none rotate-45'
+      'HOSTILE': 'rounded-none rotate-45',
+      'CIVIL': 'rounded-full'
     };
 
     const vectorAngle = Math.atan2(track.vector.dy, track.vector.dx) * 180 / Math.PI;
@@ -139,13 +178,14 @@ const ROKAFMCRCAdvanced = () => {
 
     return (
       <div key={track.id} className="absolute">
+        {/* 메인 트랙 표시 */}
         <div 
           className={`absolute ${colors[track.status]} ${shapes[track.status]} border-2 p-1.5 text-[10px] font-mono transform -translate-x-1/2 -translate-y-1/2 cursor-pointer hover:bg-opacity-80 transition-all shadow-lg`}
           style={{ 
             left: `${track.position.x}px`, 
             top: `${track.position.y}px`
           }}
-          onClick={() => { setSelectedTrack(track); setSelectedThreat(null); }}
+          onClick={() => setSelectedTrack(track)}
         >
           <div className="flex items-center space-x-1">
             <div className={`w-3 h-3 ${
@@ -160,6 +200,7 @@ const ROKAFMCRCAdvanced = () => {
           </div>
         </div>
         
+        {/* 향상된 속도/방향 벡터 */}
         <svg 
           className="absolute pointer-events-none"
           style={{ 
@@ -196,6 +237,7 @@ const ROKAFMCRCAdvanced = () => {
           />
         </svg>
 
+        {/* 항적 꼬리 (조건부 표시) */}
         {showTrails && (
           <svg 
             className="absolute pointer-events-none"
@@ -225,7 +267,7 @@ const ROKAFMCRCAdvanced = () => {
   };
 
   const renderGroundThreat = (threat: GroundThreat) => {
-    const threatColors: Record<ThreatStatus, string> = {
+    const threatColors = {
       'HIGH': '#ef4444',
       'MEDIUM': '#f97316', 
       'LOW': '#eab308'
@@ -233,6 +275,7 @@ const ROKAFMCRCAdvanced = () => {
 
     return (
       <div key={threat.id} className="absolute">
+        {/* 위협 범위 원 */}
         <svg
           className="absolute pointer-events-none"
           style={{ 
@@ -255,13 +298,13 @@ const ROKAFMCRCAdvanced = () => {
           />
         </svg>
         
+        {/* 위협 아이콘 */}
         <div 
           className="absolute transform -translate-x-1/2 -translate-y-1/2 cursor-pointer"
           style={{ 
             left: `${threat.position.x}px`, 
             top: `${threat.position.y}px`
           }}
-          onClick={() => { setSelectedThreat(threat); setSelectedTrack(null); }}
         >
           <div className="bg-red-900/60 border border-red-400 rounded p-1">
             <Skull className="w-3 h-3 text-red-400" />
@@ -275,154 +318,428 @@ const ROKAFMCRCAdvanced = () => {
   };
 
   return (
-    <div className="min-h-screen bg-black text-green-300 font-mono flex flex-col">
-      {/* Header */}
-      <header className="bg-gray-900/50 border-b border-green-900/50 p-2 flex justify-between items-center text-xs backdrop-blur-sm">
-        <div className="flex items-center space-x-4">
-          <h1 className="font-bold text-lg text-cyan-400">ROKAF MCRC V2</h1>
-          <div>TIME: {currentTime.toISOString().substr(11, 8)}Z</div>
-        </div>
-        <div className="flex items-center space-x-4">
-          <div>FPCON: <span className="text-yellow-400 font-bold">{threatLevel}</span></div>
-          <div>ALERT: <span className="text-red-500 font-bold">{alertLevel}</span></div>
-        </div>
-        <div className="flex items-center space-x-2">
-          <Settings className="w-4 h-4" />
-          <Radio className="w-4 h-4" />
-          <CloudRain className="w-4 h-4" />
-        </div>
-      </header>
-
-      {/* Main Content */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Left Sidebar */}
-        <aside className="w-64 bg-gray-900/70 border-r border-green-900/50 flex flex-col backdrop-blur-sm p-2 space-y-2">
-            <div className="bg-gray-800/50 rounded p-2">
-                <h3 className="text-cyan-400 font-bold text-sm mb-2">Filters</h3>
-                <div className="space-y-1 text-xs">
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="friendly" checked={filters.friendly} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-green-500" />
-                        <span>Friendly</span>
-                    </label>
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="unknown" checked={filters.unknown} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-yellow-500" />
-                        <span>Unknown</span>
-                    </label>
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="hostile" checked={filters.hostile} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-red-500" />
-                        <span>Hostile</span>
-                    </label>
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="ground" checked={filters.ground} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-orange-500" />
-                        <span>Ground Threats</span>
-                    </label>
-                </div>
-            </div>
-            <div className="bg-gray-800/50 rounded p-2">
-                <h3 className="text-cyan-400 font-bold text-sm mb-2">Actions</h3>
-                <div className="space-y-2">
-                    <button className="w-full text-xs bg-blue-800 hover:bg-blue-700 text-white py-1 px-2 rounded">REQUEST IFF</button>
-                    <button className="w-full text-xs bg-yellow-800 hover:bg-yellow-700 text-white py-1 px-2 rounded">CORRELATE</button>
-                    <button className="w-full text-xs bg-red-800 hover:bg-red-700 text-white py-1 px-2 rounded">INTERCEPT</button>
-                </div>
-            </div>
-        </aside>
-
-        {/* Main Map Area */}
-        <main className="flex-1 bg-gray-800/80 relative overflow-hidden" style={{
-            background: 'radial-gradient(circle, #001a00 1px, transparent 1px), repeating-linear-gradient(0deg, transparent, transparent 19px, #002a00 20px), repeating-linear-gradient(90deg, transparent, transparent 19px, #002a00 20px)',
-            backgroundSize: '20px 20px, 100% 20px, 20px 100%',
-        }}>
-            {filteredTracks.map(renderTrack)}
-            {filteredThreats.map(renderGroundThreat)}
-        </main>
-
-        {/* Right Sidebar */}
-        <aside className="w-80 bg-gray-900/70 border-l border-green-900/50 flex flex-col backdrop-blur-sm">
-          {/* Grid Sectors */}
-          <div className="p-2 border-b border-green-900/50">
-            <h2 className="text-center font-bold text-cyan-400">GRID SECTORS</h2>
-          </div>
-          <div className="overflow-y-auto text-xs" style={{ flex: '2 1 0%'}}>
-            {gridSectors.map(sector => (
-              <div key={sector.id} className={`p-2 border-b border-gray-800/50 flex justify-between items-center cursor-pointer hover:bg-green-900/30 ${selectedGrid === sector.id ? 'bg-green-800/50' : ''}`} onClick={() => setSelectedGrid(sector.id)}>
-                <div>
-                  <span className="font-bold text-cyan-300">{sector.id}</span>
-                  <div className="text-[10px] text-gray-400">{sector.controller}</div>
-                </div>
-                <div className="text-right">
-                  <div className={`font-bold text-${sector.color}-400`}>{sector.threat}</div>
-                  <div className="text-[10px]">{sector.tracks} Tracks</div>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Selected Item Info */}
-          <div className="p-2 border-t border-green-900/50">
-            <h2 className="text-center font-bold text-cyan-400">ITEM DETAILS</h2>
-          </div>
-          <div className="p-3 text-xs space-y-3 overflow-y-auto" style={{ flex: '1 1 0%'}}>
-            {selectedTrack && (
-              <div>
-                <h3 className="font-bold text-base text-cyan-300 mb-2">{selectedTrack.callsign} [{selectedTrack.id}]</h3>
-                <div className="space-y-2">
-                    <div className="p-2 bg-gray-800/50 rounded">
-                        <div className="font-bold text-yellow-400 mb-1">Primary Info</div>
-                        <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                            <span>Status:</span> <span className={`font-bold text-${selectedTrack.status === 'FRIENDLY' ? 'green' : selectedTrack.status === 'UNKNOWN' ? 'yellow' : 'red'}-400`}>{selectedTrack.status}</span>
-                            <span>Type:</span> <span>{selectedTrack.type}</span>
-                            <span>Mission:</span> <span>{selectedTrack.mission}</span>
-                            <span>Controller:</span> <span>{selectedTrack.controller}</span>
-                        </div>
-                    </div>
-                    <div className="p-2 bg-gray-800/50 rounded">
-                        <div className="font-bold text-yellow-400 mb-1">Flight Data</div>
-                        <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                            <span>Altitude:</span> <span>{selectedTrack.altitude} ft</span>
-                            <span>Speed:</span> <span>{selectedTrack.speed} kts</span>
-                            <span>Fuel:</span> <span>{selectedTrack.fuel}{typeof selectedTrack.fuel === 'number' && '%'}</span>
-                            <span>ETA:</span> <span>{selectedTrack.eta}</span>
-                        </div>
-                    </div>
-                    <div className="p-2 bg-gray-800/50 rounded">
-                        <div className="font-bold text-yellow-400 mb-1">Payload & Crew</div>
-                        <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                            <span>Pilot:</span> <span>{selectedTrack.pilot}</span>
-                            <span>Weapons:</span> <span>{selectedTrack.weapons}</span>
-                        </div>
-                    </div>
-                </div>
-              </div>
-            )}
-            {selectedThreat && (
-              <div>
-                <h3 className="font-bold text-base text-red-400 mb-2">{selectedThreat.type} [{selectedThreat.id}]</h3>
-                 <div className="p-2 bg-gray-800/50 rounded">
-                    <div className="font-bold text-yellow-400 mb-1">Threat Assessment</div>
-                    <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                        <span>Status:</span> <span className="font-bold text-yellow-400">{selectedThreat.status}</span>
-                        <span>Threat:</span> <span className={`font-bold text-${selectedThreat.threat === 'HIGH' ? 'red' : selectedThreat.threat === 'MEDIUM' ? 'orange' : 'yellow'}-400`}>{selectedThreat.threat}</span>
-                        <span>Range:</span> <span>{selectedThreat.range} km</span>
-                        <span>Position:</span> <span>{selectedThreat.position.x}, {selectedThreat.position.y}</span>
-                    </div>
-                </div>
-              </div>
-            )}
-            {!selectedTrack && !selectedThreat && (
-              <div className="text-center text-gray-500 pt-8">No Item Selected</div>
-            )}
-          </div>
-        </aside>
+    <div className="min-h-screen bg-gray-900 text-green-300 font-mono">
+      {/* TOP SECRET 헤더 */}
+      <div className="bg-red-900 text-white text-center py-1 font-bold text-xs">
+        ★★ TOP SECRET // REL TO ROKAF ★★
       </div>
 
-      {/* Footer */}
-      <footer className="bg-gray-900/50 border-t border-green-900/50 p-2 flex justify-center items-center space-x-4 text-xs backdrop-blur-sm">
-        <button onClick={() => setRadarMode(radarMode === 'WIDE_AREA' ? 'SECTOR_SCAN' : 'WIDE_AREA')} className="px-2 py-1 bg-gray-800 hover:bg-gray-700 border border-green-800 rounded">RADAR: {radarMode}</button>
-        <button onClick={() => setShowTrails(!showTrails)} className={`px-2 py-1 bg-gray-800 hover:bg-gray-700 border border-green-800 rounded ${showTrails ? 'text-cyan-400' : ''}`}>TRAILS</button>
-        <button onClick={() => setAlertLevel('HIGH')} className="px-2 py-1 bg-yellow-800/50 hover:bg-yellow-700/50 border border-yellow-800 rounded text-yellow-300">ALERT</button>
-        <button onClick={() => setAlertLevel('CRITICAL')} className="px-2 py-1 bg-red-800/50 hover:bg-red-700/50 border border-red-800 rounded text-red-300">SCRAMBLE</button>
-      </footer>
+      {/* 향상된 메인 헤더 */}
+      <div className="bg-gray-800 border-b border-gray-700 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            <div className="w-12 h-12 bg-green-700 rounded-full flex items-center justify-center border-2 border-green-400 animate-pulse">
+              <Radar className="w-8 h-8 text-green-200" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-green-300">ROKAF MCRC-II</h1>
+              <p className="text-sm text-green-500">Master Control and Reporting Center - Next Generation</p>
+            </div>
+            <div className="flex space-x-2">
+              <div className={`px-2 py-1 rounded text-xs font-bold ${
+                alertLevel === 'NORMAL' ? 'bg-green-900 text-green-300' :
+                alertLevel === 'ALERT' ? 'bg-yellow-900 text-yellow-300' : 'bg-red-900 text-red-300'
+              }`}>
+                {alertLevel}
+              </div>
+              <div className="px-2 py-1 bg-blue-900 text-blue-300 rounded text-xs font-bold">
+                OPSEC GREEN
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-8 text-xs">
+            <div className="text-center">
+              <div className="text-green-400 font-bold text-lg">{currentTime.toLocaleTimeString('en-GB', { timeZone: 'Asia/Seoul' })}</div>
+              <div className="text-green-600">KST / ZULU {currentTime.toLocaleTimeString('en-GB', { timeZone: 'UTC' })}</div>
+            </div>
+            <div className="text-center">
+              <div className="text-yellow-400 font-bold text-lg">{threatLevel}</div>
+              <div className="text-yellow-600">FORCE PROTECTION</div>
+            </div>
+            <div className="text-center">
+              <div className="text-blue-400 font-bold">AIRSPACE-1</div>
+              <div className="text-blue-600">CONTROLLED</div>
+            </div>
+            <div className="text-center">
+              <div className="text-purple-400 font-bold">{activeTracks.length}</div>
+              <div className="text-purple-600">ACTIVE TRACKS</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex h-[calc(100vh-140px)]">
+        {/* 확장된 좌측 제어판 */}
+        <div className="w-96 bg-gray-800 border-r border-gray-700 p-4 space-y-4 overflow-y-auto">
+          {/* 제어 옵션 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <Settings className="w-4 h-4 mr-2" />
+              DISPLAY CONTROL
+            </h3>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-green-600">Radar Mode</span>
+                <select
+                  value={radarMode}
+                  onChange={(e) => setRadarMode(e.target.value)}
+                  className="bg-gray-800 text-green-400 text-xs border border-gray-600 rounded px-2 py-1"
+                >
+                  <option value="WIDE_AREA">WIDE AREA</option>
+                  <option value="SECTOR_ZOOM">SECTOR ZOOM</option>
+                  <option value="THREAT_FOCUS">THREAT FOCUS</option>
+                </select>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-green-600">Show Trails</span>
+                <button
+                  onClick={() => setShowTrails(!showTrails)}
+                  className={`px-2 py-1 rounded text-xs ${showTrails ? 'bg-green-800 text-green-300' : 'bg-gray-700 text-gray-400'}`}
+                >
+                  {showTrails ? 'ON' : 'OFF'}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* 확장된 격자 구역 현황 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <Target className="w-4 h-4 mr-2" />
+              SECTOR STATUS (15 GRIDS)
+            </h3>
+            <div className="space-y-1 text-xs max-h-48 overflow-y-auto">
+              {gridSectors.map(sector => (
+                <div
+                  key={sector.id}
+                  className={`flex justify-between items-center p-2 rounded border ${
+                    selectedGrid === sector.id ? 'bg-blue-900/30 border-blue-500' : 'border-gray-600'
+                  } cursor-pointer hover:border-green-500 transition-colors`}
+                  onClick={() => setSelectedGrid(sector.id)}
+                >
+                  <div>
+                    <div className="text-green-300 font-bold">{sector.id}</div>
+                    <div className="text-green-600 text-[10px]">{sector.controller}</div>
+                    <div className="text-blue-400 text-[10px]">{sector.activity}</div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-green-400 font-bold">{sector.tracks}</div>
+                    <div className={`text-[10px] ${
+                      sector.threat === 'LOW' ? 'text-green-500' :
+                      sector.threat === 'MEDIUM' ? 'text-yellow-500' :
+                      sector.threat === 'HIGH' ? 'text-orange-500' : 'text-red-500'
+                    }`}>
+                      {sector.threat}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 향상된 시스템 상태 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <Activity className="w-4 h-4 mr-2" />
+              SYSTEM STATUS
+            </h3>
+            <div className="space-y-2 text-xs">
+              {[
+                { name: 'AN/FPS-117', status: 'ONLINE', param: '6.0s', quality: 98 },
+                { name: 'AN/TPS-43G', status: 'ONLINE', param: 'MODE-S', quality: 95 },
+                { name: 'LINK-16 TDL', status: 'SECURE', param: 'NPG-1', quality: 99 },
+                { name: 'SATCOM MILSTAR', status: 'ONLINE', param: 'EHF', quality: 97 },
+                { name: 'IFF MODE-4/5', status: 'ACTIVE', param: 'CRYPTO', quality: 100 },
+                { name: 'AEGIS SPY-1D', status: 'STANDBY', param: 'READY', quality: 92 },
+                { name: 'PATRIOT AN/MPQ', status: 'TRACKING', param: 'TBM', quality: 94 },
+                { name: 'THAAD AN/TPY-2', status: 'SEARCH', param: 'X-BAND', quality: 96 }
+              ].map(sys => (
+                <div key={sys.name} className="flex justify-between items-center">
+                  <span className="text-green-600">{sys.name}</span>
+                  <div className="text-right">
+                    <span className="text-green-400">{sys.status}</span>
+                    <div className="text-green-500">{sys.param} ({sys.quality}%)</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 위협 평가 */}
+          <div className="bg-red-900/20 rounded-lg p-3 border border-red-700">
+            <h3 className="text-sm font-bold text-red-400 mb-3 flex items-center">
+              <Flame className="w-4 h-4 mr-2" />
+              THREAT ASSESSMENT
+            </h3>
+            <div className="space-y-2 text-xs">
+              {groundThreats.map(threat => (
+                <div key={threat.id} className="flex justify-between items-center">
+                  <span className="text-red-300">{threat.id}</span>
+                  <div className="text-right">
+                    <div className="text-red-400">{threat.type}</div>
+                    <div className={`${
+                      threat.threat === 'HIGH' ? 'text-red-500' :
+                      threat.threat === 'MEDIUM' ? 'text-orange-500' : 'text-yellow-500'
+                    }`}>
+                      {threat.status} - {threat.threat}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 고급 제어 */}
+          <div className="bg-purple-900/20 rounded-lg p-3 border border-purple-700">
+            <h3 className="text-sm font-bold text-purple-400 mb-3 flex items-center">
+              <Zap className="w-4 h-4 mr-2" />
+              BATTLE MANAGEMENT
+            </h3>
+            <div className="space-y-2">
+              <button
+                onClick={() => setAlertLevel(alertLevel === 'NORMAL' ? 'ALERT' : alertLevel === 'ALERT' ? 'CRITICAL' : 'NORMAL')}
+                className="w-full bg-purple-800 hover:bg-purple-700 text-white py-1 px-2 rounded text-xs"
+              >
+                ESCALATE ALERT LEVEL
+              </button>
+              <button className="w-full bg-red-800 hover:bg-red-700 text-white py-1 px-2 rounded text-xs">
+                ACTIVATE AIR DEFENSE
+              </button>
+              <button className="w-full bg-orange-800 hover:bg-orange-700 text-white py-1 px-2 rounded text-xs">
+                LAUNCH INTERCEPTORS
+              </button>
+              <button className="w-full bg-blue-800 hover:bg-blue-700 text-white py-1 px-2 rounded text-xs">
+                COORDINATE STRIKE
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* 향상된 중앙 지도 영역 */}
+        <div className="flex-1 bg-gray-900 relative overflow-hidden">
+          {/* 고해상도 동아시아 지도 배경 */}
+          <svg className="absolute inset-0 w-full h-full" viewBox="0 0 1000 700">
+            {/* 정밀 격자 체계 */}
+            <defs>
+              <pattern id="grid" width="66" height="46" patternUnits="userSpaceOnUse">
+                <path d="M 66 0 L 0 0 0 46" fill="none" stroke="rgba(34, 197, 94, 0.3)" strokeWidth="0.5"/>
+              </pattern>
+              <pattern id="majorGrid" width="200" height="140" patternUnits="userSpaceOnUse">
+                <path d="M 200 0 L 0 0 0 140" fill="none" stroke="rgba(34, 197, 94, 0.6)" strokeWidth="1"/>
+              </pattern>
+            </defs>
+            <rect width="100%" height="100%" fill="url(#grid)" />
+            <rect width="100%" height="100%" fill="url(#majorGrid)" />
+
+            {/* 격자 라벨 (5x3 = 15개 구역) */}
+            {['IE-06', 'IE-10', 'IE-14'].map((label, i) => (
+              <text key={label} x={150 + i*200} y={90} fill="#22c55e" fontSize="14" textAnchor="middle" fontWeight="bold">{label}</text>
+            ))}
+            {['JE-06', 'JE-10', 'JE-14'].map((label, i) => (
+              <text key={label} x={150 + i*200} y={230} fill="#22c55e" fontSize="14" textAnchor="middle" fontWeight="bold">{label}</text>
+            ))}
+            {['KE-06', 'KE-10', 'KE-14'].map((label, i) => (
+              <text key={label} x={150 + i*200} y={370} fill="#22c55e" fontSize="14" textAnchor="middle" fontWeight="bold">{label}</text>
+            ))}
+            {['LE-06', 'LE-10', 'LE-14'].map((label, i) => (
+              <text key={label} x={150 + i*200} y={510} fill="#22c55e" fontSize="14" textAnchor="middle" fontWeight="bold">{label}</text>
+            ))}
+            {['ME-06', 'ME-10', 'ME-14'].map((label, i) => (
+              <text key={label} x={150 + i*200} y={650} fill="#22c55e" fontSize="14" textAnchor="middle" fontWeight="bold">{label}</text>
+            ))}
+
+            {/* 상세 한반도 지형 */}
+            <path
+              d="M 480 280 L 495 270 L 510 275 L 525 285 L 535 310 L 540 340 L 535 370 L 525 395 L 515 405 L 500 410 L 485 405 L 470 395 L 460 370 L 465 340 L 480 310 Z"
+              fill="rgba(34, 197, 94, 0.3)"
+              stroke="#22c55e"
+              strokeWidth="2"
+            />
+
+            {/* 상세 DMZ */}
+            <line x1="460" y1="310" x2="540" y2="310" stroke="#ef4444" strokeWidth="3" strokeDasharray="6,6" />
+            <text x="500" y="305" fill="#ef4444" fontSize="12" textAnchor="middle" fontWeight="bold">DMZ - 비무장지대</text>
+
+            {/* 중국 대륙 */}
+            <path
+              d="M 50 200 L 150 220 L 250 240 L 350 260 L 400 290 L 420 330 L 400 370 L 350 400 L 250 420 L 150 440 L 50 460"
+              fill="none"
+              stroke="rgba(34, 197, 94, 0.7)"
+              strokeWidth="3"
+            />
+            <text x="250" y="330" fill="#22c55e" fontSize="18" fontWeight="bold">CHINA (PRC)</text>
+
+            {/* 일본 열도 상세 */}
+            <ellipse cx="650" cy="330" rx="45" ry="120" fill="rgba(34, 197, 94, 0.3)" stroke="#22c55e" strokeWidth="2" />
+            <ellipse cx="720" cy="350" rx="30" ry="90" fill="rgba(34, 197, 94, 0.3)" stroke="#22c55e" strokeWidth="2" />
+            <ellipse cx="780" cy="370" rx="20" ry="60" fill="rgba(34, 197, 94, 0.3)" stroke="#22c55e" strokeWidth="2" />
+            <text x="650" y="335" fill="#22c55e" fontSize="16" textAnchor="middle" fontWeight="bold">JAPAN</text>
+
+            {/* 러시아 연방 */}
+            <line x1="50" y1="150" x2="950" y2="150" stroke="rgba(34, 197, 94, 0.7)" strokeWidth="3" />
+            <text x="500" y="140" fill="#22c55e" fontSize="18" textAnchor="middle" fontWeight="bold">RUSSIAN FEDERATION</text>
+
+            {/* 북한 */}
+            <path
+              d="M 480 220 L 500 210 L 520 215 L 535 230 L 540 250 L 535 280 L 500 310 L 480 310 L 465 280 L 470 250 L 480 230 Z"
+              fill="rgba(239, 68, 68, 0.2)"
+              stroke="#ef4444"
+              strokeWidth="2"
+            />
+            <text x="500" y="265" fill="#ef4444" fontSize="12" textAnchor="middle" fontWeight="bold">DPRK</text>
+
+            {/* 주요 도시 표시 */}
+            <circle cx="500" cy="380" r="3" fill="#22c55e" />
+            <text x="505" y="385" fill="#22c55e" fontSize="10">SEOUL</text>
+            <circle cx="520" cy="420" r="2" fill="#22c55e" />
+            <text x="525" y="425" fill="#22c55e" fontSize="10">BUSAN</text>
+          </svg>
+
+          {/* 지상 위협 표시 */}
+          <div className="absolute inset-0">
+            {groundThreats.map(threat => renderGroundThreat(threat))}
+          </div>
+
+          {/* 실시간 항적 표시 */}
+          <div className="absolute inset-0">
+            {activeTracks.map(track => renderTrack(track))}
+          </div>
+
+          {/* 향상된 레이더 스위프 */}
+          <div className="absolute top-4 right-4 w-32 h-32 bg-green-900/20 rounded-full border-2 border-green-600 flex items-center justify-center">
+            <div className="animate-spin w-full h-full flex items-center justify-center">
+              <div className="w-28 h-0.5 bg-gradient-to-r from-green-400 via-green-300 to-transparent origin-left"></div>
+            </div>
+            <div className="absolute text-xs text-green-400 bottom-2">1200NM</div>
+            <div className="absolute text-xs text-green-600 top-2">{radarMode}</div>
+          </div>
+
+          {/* 실시간 상태 표시 */}
+          <div className="absolute bottom-4 left-4 bg-gray-900/80 rounded-lg p-2 border border-gray-700">
+            <div className="text-xs text-green-400 space-y-1">
+              <div>총 항적: <span className="text-green-300 font-bold">{activeTracks.length}</span></div>
+              <div>아군: <span className="text-green-300">{activeTracks.filter(t => t.status === 'FRIENDLY').length}</span></div>
+              <div>미식별: <span className="text-yellow-300">{activeTracks.filter(t => t.status === 'UNKNOWN').length}</span></div>
+              <div>적성: <span className="text-red-300">{activeTracks.filter(t => t.status === 'HOSTILE').length}</span></div>
+            </div>
+          </div>
+        </div>
+
+        {/* 확장된 우측 정보 패널 */}
+        <div className="w-96 bg-gray-800 border-l border-gray-700 p-4 space-y-4 overflow-y-auto">
+          {/* 선택된 항적 상세 정보 */}
+          {selectedTrack && (
+            <div className="bg-gray-900 rounded-lg p-3 border-l-4 border-blue-500">
+              <h3 className="text-sm font-bold text-blue-400 mb-3 flex items-center">
+                <Crosshair className="w-4 h-4 mr-2" />
+                TRACK DETAILS
+              </h3>
+              <div className="text-xs space-y-2">
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="text-green-600">Callsign:</div>
+                  <div className="text-green-300 font-bold">{selectedTrack.callsign}</div>
+                  <div className="text-green-600">Type:</div>
+                  <div className="text-green-300">{selectedTrack.type}</div>
+                  <div className="text-green-600">Mission:</div>
+                  <div className="text-green-300">{selectedTrack.mission}</div>
+                  <div className="text-green-600">Altitude:</div>
+                  <div className="text-green-300">{selectedTrack.altitude}ft</div>
+                  <div className="text-green-600">Speed:</div>
+                  <div className="text-green-300">{selectedTrack.speed}kt</div>
+                  <div className="text-green-600">Fuel:</div>
+                  <div className="text-green-300">{selectedTrack.fuel}%</div>
+                  <div className="text-green-600">Weapons:</div>
+                  <div className="text-green-300">{selectedTrack.weapons}</div>
+                  <div className="text-green-600">Pilot:</div>
+                  <div className="text-green-300">{selectedTrack.pilot}</div>
+                  <div className="text-green-600">ETA RTB:</div>
+                  <div className="text-green-300">{selectedTrack.eta}</div>
+                  <div className="text-green-600">Controller:</div>
+                  <div className="text-green-300">{selectedTrack.controller}</div>
+                </div>
+                <div className="mt-3 pt-2 border-t border-gray-700">
+                  <div className={`px-2 py-1 rounded text-center font-bold ${
+                    selectedTrack.status === 'FRIENDLY' ? 'bg-green-900 text-green-300' :
+                    selectedTrack.status === 'UNKNOWN' ? 'bg-yellow-900 text-yellow-300' :
+                    'bg-red-900 text-red-300'
+                  }`}>
+                    {selectedTrack.status}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 임무별 항적 분류 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <Plane className="w-4 h-4 mr-2" />
+              MISSION BREAKDOWN
+            </h3>
+            <div className="space-y-2 text-xs">
+              {Object.entries(
+                activeTracks.reduce((acc, track) => {
+                  acc[track.mission] = (acc[track.mission] || 0) + 1;
+                  return acc;
+                }, {} as Record<string, number>)
+              ).map(([mission, count]) => (
+                <div key={mission} className="flex justify-between items-center">
+                  <span className="text-green-600">{mission}</span>
+                  <span className="text-green-300 font-bold">{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 실시간 통신 로그 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <Radio className="w-4 h-4 mr-2" />
+              COMM LOG
+            </h3>
+            <div className="text-xs space-y-1 max-h-32 overflow-y-auto">
+              <div className="text-green-600">[{currentTime.toLocaleTimeString()}] VIPER-01: Fuel check 68%</div>
+              <div className="text-yellow-600">[{currentTime.toLocaleTimeString()}] UNKNOWN-1: No IFF response</div>
+              <div className="text-red-600">[{currentTime.toLocaleTimeString()}] BANDIT-1: Hostile track confirmed</div>
+              <div className="text-green-600">[{currentTime.toLocaleTimeString()}] HAWK-01: ISR mission complete</div>
+            </div>
+          </div>
+
+          {/* 날씨 및 환경 정보 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <CloudRain className="w-4 h-4 mr-2" />
+              ENVIRONMENTAL
+            </h3>
+            <div className="text-xs space-y-1">
+              <div className="grid grid-cols-2 gap-2">
+                <div className="text-green-600">RKSS Wind:</div>
+                <div className="text-green-300">280°/18kt G25kt</div>
+                <div className="text-green-600">Visibility:</div>
+                <div className="text-green-300">15km</div>
+                <div className="text-green-600">Cloud Base:</div>
+                <div className="text-green-300">2800ft AGL</div>
+                <div className="text-green-600">QNH:</div>
+                <div className="text-green-300">1015.8 hPa</div>
+                <div className="text-green-600">Temperature:</div>
+                <div className="text-green-300">18°C</div>
+                <div className="text-green-600">Dewpoint:</div>
+                <div className="text-green-300">12°C</div>
+              </div>
+              <div className="mt-2 text-yellow-500">
+                <div>⚠ SIGMET: Severe turbulence FL280-380</div>
+                <div>⚠ AIRMET: Mountain wave activity</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 하단 분류 표시 */}
+      <div className="bg-red-900 text-white text-center py-1 font-bold text-xs">
+        ★★ TOP SECRET // REL TO ROKAF ★★
+      </div>
     </div>
   );
 };

--- a/src/samples/rokaf-sector-ke14-operations.tsx
+++ b/src/samples/rokaf-sector-ke14-operations.tsx
@@ -1,15 +1,20 @@
 import React, { useState, useEffect } from 'react';
 import { 
-  Target, Radio,
-  AlertTriangle,
-  Users, Settings,
-  BarChart3,
-  MessageSquare,
-  Crosshair
+  Shield, Target, Navigation, Radar, Radio, Satellite,
+  AlertTriangle, CheckCircle, XCircle, Clock, Battery,
+  Eye, Camera, Crosshair, Map, Globe, Zap, Activity,
+  Users, Settings, Bell, Download, Upload, RefreshCw,
+  Plane, Wind, Thermometer, CloudRain, Sun, Moon,
+  Lock, Unlock, Key, FileText, Headphones, Mic,
+  Flame, Skull, Minus, Plus, Maximize, Minimize,
+  Brain, Bot, TrendingUp, BarChart3, Cpu, Network,
+  AlertCircle, PlayCircle, PauseCircle, FastForward,
+  Volume2, VolumeX, Phone, PhoneCall, MessageSquare,
+  MonitorSpeaker, Layers, MapPin, Route
 } from 'lucide-react';
 
 type OperatorStatus = 'ACTIVE' | 'STANDBY' | 'OFFLINE';
-type Workload = 'HIGH' | 'MODERATE' | 'LOW' | 'NORMAL';
+type Workload = 'HIGH' | 'MODERATE' | 'LOW';
 type TrackStatus = 'FRIENDLY' | 'UNKNOWN' | 'HOSTILE';
 
 interface Operator {
@@ -42,26 +47,14 @@ interface SectorTrack {
   lastContact: string;
 }
 
-import { Filter, Zap } from 'lucide-react';
-
 const ROKAFSectorKE14Detail = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
   const [selectedOperator, setSelectedOperator] = useState('OPS-01');
+  const [commsChannel, setCommsChannel] = useState('PRIMARY');
   const [alertStatus, setAlertStatus] = useState('GREEN');
   const [selectedTrack, setSelectedTrack] = useState<SectorTrack | null>(null);
-  const [filters, setFilters] = useState({
-    friendly: true,
-    unknown: true,
-    hostile: false, // No hostile tracks in this sample
-    air: true,
-    helo: true,
-  });
 
-  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, checked } = event.target;
-    setFilters(prev => ({ ...prev, [name]: checked }));
-  };
-
+  // 섹터 KE-14 담당 운영진
   const operatorStations: Operator[] = [
     {
       id: 'OPS-01',
@@ -125,6 +118,7 @@ const ROKAFSectorKE14Detail = () => {
     }
   ];
 
+  // KE-14 섹터 내 상세 항적
   const sectorTracks: SectorTrack[] = [
     {
       id: 'KE14-001',
@@ -218,23 +212,14 @@ const ROKAFSectorKE14Detail = () => {
     }
   ];
 
-  const [commLog] = useState([
+  // 활성 통신 로그
+  const [commLog, setCommLog] = useState<{time: Date, from: string, to: string, message: string, priority: string, channel: string}[]>([
     { time: new Date(), from: 'VIPER-03', to: 'OPS-03', message: 'Request vector to target area Alpha', priority: 'ROUTINE', channel: 'AIR-GROUND' },
     { time: new Date(Date.now() - 30000), from: 'OPS-04', to: 'INTEL-NET', message: 'Unknown track classification request - Squawk 7600', priority: 'PRIORITY', channel: 'DATA-LINK' },
     { time: new Date(Date.now() - 60000), from: 'CARGO-12', to: 'OPS-02', message: 'Requesting flight level change to FL200 due weather', priority: 'ROUTINE', channel: 'AIR-GROUND' },
     { time: new Date(Date.now() - 90000), from: 'OPS-01', to: 'MCRC', message: 'KE-14 sector status normal, 5 active tracks', priority: 'ROUTINE', channel: 'COMMAND' },
     { time: new Date(Date.now() - 120000), from: 'RESCUE-07', to: 'OPS-03', message: 'Medical emergency, requesting priority handling', priority: 'URGENT', channel: 'SAR-COORD' }
   ]);
-
-  const filteredTracks = sectorTracks.filter(track => {
-    if (track.status === 'FRIENDLY' && !filters.friendly) return false;
-    if (track.status === 'UNKNOWN' && !filters.unknown) return false;
-    if (track.status === 'HOSTILE' && !filters.hostile) return false;
-    const type = track.type.toLowerCase();
-    if ((type.includes('f-16') || type.includes('c-130')) && !filters.air) return false;
-    if ((type.includes('uh-60') || type.includes('surion')) && !filters.helo) return false;
-    return true;
-  });
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -245,17 +230,16 @@ const ROKAFSectorKE14Detail = () => {
 
   const renderOperatorStation = (operator: Operator) => {
     const isSelected = selectedOperator === operator.id;
-    const statusColors: Record<OperatorStatus, string> = {
+    const statusColors = {
       'ACTIVE': 'border-green-500 bg-green-900/20',
       'STANDBY': 'border-yellow-500 bg-yellow-900/20',
       'OFFLINE': 'border-red-500 bg-red-900/20'
     };
 
-    const workloadColors: Record<Workload, string> = {
+    const workloadColors = {
       'HIGH': 'text-red-400',
       'MODERATE': 'text-yellow-400', 
-      'LOW': 'text-green-400',
-      'NORMAL': 'text-green-400'
+      'LOW': 'text-green-400'
     };
 
     return (
@@ -286,7 +270,7 @@ const ROKAFSectorKE14Detail = () => {
           <div className="text-blue-400">{operator.responsibility}</div>
           
           <div className="flex flex-wrap gap-1 mt-2">
-            {operator.commChannels.slice(0, 2).map((channel: string) => (
+            {operator.commChannels.slice(0, 2).map(channel => (
               <span key={channel} className="bg-purple-900/50 text-purple-300 px-1 py-0.5 rounded text-[10px]">
                 {channel}
               </span>
@@ -301,7 +285,7 @@ const ROKAFSectorKE14Detail = () => {
   };
 
   const renderTrack = (track: SectorTrack) => {
-    const colors: Record<TrackStatus, string> = {
+    const colors = {
       'FRIENDLY': 'text-green-400 bg-green-900/30 border-green-400',
       'UNKNOWN': 'text-yellow-400 bg-yellow-900/30 border-yellow-400',
       'HOSTILE': 'text-red-400 bg-red-900/30 border-red-400'
@@ -330,6 +314,7 @@ const ROKAFSectorKE14Detail = () => {
           </div>
         </div>
         
+        {/* 벡터 표시 */}
         <svg 
           className="absolute pointer-events-none"
           style={{ 
@@ -364,140 +349,392 @@ const ROKAFSectorKE14Detail = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-green-300 font-mono flex flex-col">
-      {/* Header */}
-      <header className="bg-gray-800/80 border-b border-green-800/50 p-3 flex justify-between items-center text-sm backdrop-blur-sm">
-        <div className="flex items-center space-x-4">
-          <h1 className="font-bold text-xl text-cyan-400">SECTOR KE-14 OPERATIONS</h1>
-          <div className="text-xs">TIME: {currentTime.toLocaleTimeString('en-US', { hour12: false })}Z</div>
-        </div>
-        <div className={`border-2 p-2 rounded-lg ${
-          alertStatus === 'GREEN' ? 'border-green-500' :
-          alertStatus === 'YELLOW' ? 'border-yellow-500' : 'border-red-500'
-        }`}>
-          <div className="flex items-center space-x-2">
-            <AlertTriangle className={`w-6 h-6 ${
-              alertStatus === 'GREEN' ? 'text-green-500' :
-              alertStatus === 'YELLOW' ? 'text-yellow-500' : 'text-red-500'
-            }`} />
-            <span className="font-bold text-lg">ALERT STATUS: {alertStatus}</span>
-          </div>
-        </div>
-        <div className="flex items-center space-x-3">
-          <Settings className="w-5 h-5 cursor-pointer hover:text-cyan-300" />
-          <Users className="w-5 h-5 cursor-pointer hover:text-cyan-300" />
-          <BarChart3 className="w-5 h-5 cursor-pointer hover:text-cyan-300" />
-        </div>
-      </header>
-
-      {/* Main Content Area */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Left Sidebar: Operator Stations */}
-        <aside className="w-1/4 bg-gray-800/50 border-r border-green-800/50 p-3 flex flex-col space-y-4">
-          <div>
-            <h2 className="text-lg font-bold text-center text-cyan-400 mb-3">OPERATOR STATIONS</h2>
-            <div className="grid grid-cols-1 gap-3 max-h-96 overflow-y-auto">
-              {operatorStations.map(renderOperatorStation)}
-            </div>
-          </div>
-          <div className="flex-grow space-y-4">
-            <div className="bg-gray-900/50 rounded p-2">
-                <h3 className="text-cyan-400 font-bold text-sm mb-2 flex items-center"><Filter className="w-4 h-4 mr-2" />Filters</h3>
-                <div className="space-y-1 text-xs">
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="friendly" checked={filters.friendly} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-green-500" />
-                        <span>Friendly</span>
-                    </label>
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="unknown" checked={filters.unknown} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-yellow-500" />
-                        <span>Unknown</span>
-                    </label>
-                    <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="air" checked={filters.air} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-blue-500" />
-                        <span>Fixed-Wing</span>
-                    </label>
-                     <label className="flex items-center space-x-2 cursor-pointer">
-                        <input type="checkbox" name="helo" checked={filters.helo} onChange={handleFilterChange} className="form-checkbox bg-gray-700 border-gray-600 text-purple-500" />
-                        <span>Helicopters</span>
-                    </label>
-                </div>
-            </div>
-            <div className="bg-gray-900/50 rounded p-2">
-                <h3 className="text-cyan-400 font-bold text-sm mb-2 flex items-center"><Zap className="w-4 h-4 mr-2" />Actions</h3>
-                <div className="space-y-2">
-                    <button disabled={!selectedTrack} className="w-full text-xs bg-blue-800 hover:bg-blue-700 text-white py-1 px-2 rounded disabled:bg-gray-600 disabled:cursor-not-allowed">VECTOR</button>
-                    <button disabled={!selectedTrack} className="w-full text-xs bg-yellow-800 hover:bg-yellow-700 text-white py-1 px-2 rounded disabled:bg-gray-600 disabled:cursor-not-allowed">HANDOVER</button>
-                    <button disabled={!selectedTrack || selectedTrack.status !== 'UNKNOWN'} className="w-full text-xs bg-red-800 hover:bg-red-700 text-white py-1 px-2 rounded disabled:bg-gray-600 disabled:cursor-not-allowed">WARN</button>
-                </div>
-            </div>
-          </div>
-        </aside>
-
-        {/* Center: Tactical Map */}
-        <main className="flex-1 bg-black/50 relative" style={{
-          background: 'radial-gradient(circle, #001a00 1px, transparent 1px), repeating-linear-gradient(0deg, transparent, transparent 24px, #002a00 25px), repeating-linear-gradient(90deg, transparent, transparent 24px, #002a00 25px)',
-          backgroundSize: '25px 25px, 100% 25px, 25px 100%',
-        }}>
-          {filteredTracks.map(renderTrack)}
-        </main>
-
-        {/* Right Sidebar: Track Details */}
-        <aside className="w-1/4 bg-gray-800/50 border-l border-green-800/50 p-3 overflow-y-auto">
-            <h2 className="text-lg font-bold text-center text-cyan-400 mb-3">TRACK DETAILS</h2>
-            {selectedTrack ? (
-              <div className="text-xs space-y-3">
-                <h3 className={`font-bold text-base text-center mb-2 text-${selectedTrack.status === 'FRIENDLY' ? 'green' : selectedTrack.status === 'UNKNOWN' ? 'yellow' : 'red'}-400`}>
-                  {selectedTrack.callsign} [{selectedTrack.id}]
-                </h3>
-                <div className="space-y-2">
-                    <div className="p-2 bg-gray-900/50 rounded">
-                        <div className="font-bold text-yellow-400 mb-1">Mission & Status</div>
-                        <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                            <span>Status:</span> <span className={`font-bold text-${selectedTrack.status === 'FRIENDLY' ? 'green' : selectedTrack.status === 'UNKNOWN' ? 'yellow' : 'red'}-400`}>{selectedTrack.status}</span>
-                            <span>Mission:</span> <span>{selectedTrack.mission}</span>
-                            <span>Controller:</span> <span>{selectedTrack.controller}</span>
-                            <span>Pilot:</span> <span>{selectedTrack.pilot}</span>
-                        </div>
-                    </div>
-                     <div className="p-2 bg-gray-900/50 rounded">
-                        <div className="font-bold text-yellow-400 mb-1">Flight Data</div>
-                        <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                            <span>Altitude:</span> <span>{selectedTrack.altitude} ft</span>
-                            <span>Speed:</span> <span>{selectedTrack.speed} kts</span>
-                            <span>Heading:</span> <span>{selectedTrack.heading}°</span>
-                            <span>Fuel:</span> <span>{selectedTrack.fuel}{typeof selectedTrack.fuel === 'number' && '%'}</span>
-                        </div>
-                    </div>
-                    <div className="p-2 bg-gray-900/50 rounded">
-                        <div className="font-bold text-yellow-400 mb-1">System & Comms</div>
-                         <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-                            <span>Squawk:</span><span className="text-purple-400">{selectedTrack.squawk}</span>
-                            <span>Comm Freq:</span><span>{selectedTrack.commsFreq}</span>
-                            <span>Last Ping:</span><span>{selectedTrack.lastContact}</span>
-                        </div>
-                    </div>
-                </div>
-              </div>
-            ) : (
-              <div className="text-center text-gray-500 pt-10">No Track Selected</div>
-            )}
-        </aside>
+    <div className="min-h-screen bg-gray-900 text-green-300 font-mono">
+      {/* 섹터 전용 헤더 */}
+      <div className="bg-red-900 text-white text-center py-1 font-bold text-xs">
+        ★★ TOP SECRET // REL TO ROKAF // SECTOR KE-14 OPERATIONS ★★
       </div>
 
-      {/* Footer / Comms Log */}
-      <footer className="h-40 bg-gray-800/80 border-t border-green-800/50 p-3 flex flex-col backdrop-blur-sm">
-        <h2 className="text-lg font-bold text-cyan-400 mb-2 flex items-center"><MessageSquare className="w-5 h-5 mr-2" />COMMS LOG</h2>
-        <div className="flex-1 overflow-y-auto text-xs space-y-1">
-          {commLog.map((log, index) => (
-            <div key={index} className="flex space-x-2 items-start">
-              <span className="text-gray-500">{log.time.toLocaleTimeString('en-US', { hour12: false })}</span>
-              <span className={`font-bold w-24 ${log.priority === 'URGENT' ? 'text-red-500' : log.priority === 'PRIORITY' ? 'text-yellow-500' : 'text-green-500'}`}>{log.from} &gt; {log.to}</span>
-              <p className="flex-1 text-gray-300">{log.message}</p>
-              <span className="text-purple-400 text-[10px]">({log.channel})</span>
+      {/* 섹터 상세 헤더 */}
+      <div className="bg-gray-800 border-b border-gray-700 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            <div className="w-12 h-12 bg-blue-700 rounded-full flex items-center justify-center border-2 border-blue-400">
+              <Target className="w-8 h-8 text-blue-200" />
             </div>
-          ))}
+            <div>
+              <h1 className="text-2xl font-bold text-blue-300">SECTOR KE-14</h1>
+              <p className="text-sm text-blue-500">Detailed Operations Center - Eastern Central Zone</p>
+            </div>
+            <div className="flex space-x-2">
+              <div className={`px-3 py-1 rounded text-sm font-bold border-2 ${
+                alertStatus === 'GREEN' ? 'bg-green-900 text-green-300 border-green-400' :
+                alertStatus === 'YELLOW' ? 'bg-yellow-900 text-yellow-300 border-yellow-400' :
+                'bg-red-900 text-red-300 border-red-400'
+              }`}>
+                ALERT {alertStatus}
+              </div>
+              <div className="px-2 py-1 bg-blue-900 text-blue-300 rounded text-xs font-bold">
+                6 OPERATORS
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-8 text-xs">
+            <div className="text-center">
+              <div className="text-green-400 font-bold text-lg">{currentTime.toLocaleTimeString('en-GB')}</div>
+              <div className="text-green-600">LOCAL / ZULU {currentTime.toUTCString().slice(17, 25)}</div>
+            </div>
+            <div className="text-center">
+              <div className="text-blue-400 font-bold text-lg">{sectorTracks.length}</div>
+              <div className="text-blue-600">ACTIVE TRACKS</div>
+            </div>
+            <div className="text-center">
+              <div className="text-purple-400 font-bold">CPT Park M.S.</div>
+              <div className="text-purple-600">SECTOR COMMANDER</div>
+            </div>
+          </div>
         </div>
-      </footer>
+      </div>
+
+      <div className="flex h-[calc(100vh-140px)]">
+        {/* 좌측: 운영진 상태 패널 */}
+        <div className="w-80 bg-gray-800 border-r border-gray-700 p-4 space-y-4 overflow-y-auto">
+          {/* 운영진 스테이션 현황 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-blue-400 mb-3 flex items-center">
+              <Users className="w-4 h-4 mr-2" />
+              OPERATOR STATIONS
+            </h3>
+            <div className="space-y-2">
+              {operatorStations.map(operator => renderOperatorStation(operator))}
+            </div>
+          </div>
+
+          {/* 섹터 통계 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <BarChart3 className="w-4 h-4 mr-2" />
+              SECTOR STATISTICS
+            </h3>
+            <div className="text-xs space-y-2">
+              <div className="flex justify-between">
+                <span className="text-green-600">Total Aircraft:</span>
+                <span className="text-green-300 font-bold">{sectorTracks.length}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-green-600">Friendly:</span>
+                <span className="text-green-400">{sectorTracks.filter(t => t.status === 'FRIENDLY').length}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-green-600">Unknown:</span>
+                <span className="text-yellow-400">{sectorTracks.filter(t => t.status === 'UNKNOWN').length}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-green-600">Active Controllers:</span>
+                <span className="text-blue-400">{operatorStations.filter(o => o.status === 'ACTIVE').length}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-green-600">Comm Channels:</span>
+                <span className="text-purple-400">15 Active</span>
+              </div>
+            </div>
+          </div>
+
+          {/* 통신 채널 상태 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-purple-400 mb-3 flex items-center">
+              <Radio className="w-4 h-4 mr-2" />
+              COMM CHANNELS
+            </h3>
+            <div className="text-xs space-y-2">
+              {[
+                { freq: '251.75', name: 'PRIMARY AIR-GROUND', status: 'ACTIVE', users: 3 },
+                { freq: '243.00', name: 'SECONDARY A-G', status: 'ACTIVE', users: 2 },
+                { freq: '255.40', name: 'SAR COORDINATION', status: 'ACTIVE', users: 1 },
+                { freq: '279.15', name: 'MEDEVAC FREQ', status: 'ACTIVE', users: 1 },
+                { freq: '311.00', name: 'COMMAND NET', status: 'ACTIVE', users: 4 },
+                { freq: '295.80', name: 'INTER-SECTOR', status: 'STANDBY', users: 0 }
+              ].map(channel => (
+                <div key={channel.freq} className="flex justify-between items-center p-1 border border-gray-600 rounded">
+                  <div>
+                    <div className="text-purple-300 font-bold">{channel.freq}</div>
+                    <div className="text-green-600 text-[10px]">{channel.name}</div>
+                  </div>
+                  <div className="text-right">
+                    <div className={`text-xs font-bold ${
+                      channel.status === 'ACTIVE' ? 'text-green-400' :
+                      channel.status === 'SECURE' ? 'text-blue-400' : 'text-yellow-400'
+                    }`}>
+                      {channel.status}
+                    </div>
+                    <div className="text-gray-400 text-[10px]">{channel.users} users</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 긴급 대응 */}
+          <div className="bg-red-900/20 rounded-lg p-3 border border-red-700">
+            <h3 className="text-sm font-bold text-red-400 mb-3 flex items-center">
+              <AlertTriangle className="w-4 h-4 mr-2" />
+              EMERGENCY ACTIONS
+            </h3>
+            <div className="space-y-2">
+              <button
+                onClick={() => setAlertStatus(alertStatus === 'GREEN' ? 'YELLOW' : alertStatus === 'YELLOW' ? 'RED' : 'GREEN')}
+                className="w-full bg-red-800 hover:bg-red-700 text-white py-1 px-2 rounded text-xs"
+              >
+                ESCALATE ALERT LEVEL
+              </button>
+              <button className="w-full bg-orange-800 hover:bg-orange-700 text-white py-1 px-2 rounded text-xs">
+                REQUEST ASSISTANCE
+              </button>
+              <button className="w-full bg-purple-800 hover:bg-purple-700 text-white py-1 px-2 rounded text-xs">
+                ACTIVATE BACKUP
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* 중앙: 섹터 상세 지도 */}
+        <div className="flex-1 bg-gray-900 relative overflow-hidden">
+          {/* 섹터 KE-14 상세 지도 */}
+          <svg className="absolute inset-0 w-full h-full" viewBox="0 0 400 300">
+            {/* 섹터 경계선 */}
+            <defs>
+              <pattern id="sectorGrid" width="20" height="20" patternUnits="userSpaceOnUse">
+                <path d="M 20 0 L 0 0 0 20" fill="none" stroke="rgba(59, 130, 246, 0.3)" strokeWidth="0.5"/>
+              </pattern>
+            </defs>
+            <rect width="100%" height="100%" fill="url(#sectorGrid)" />
+
+            {/* 섹터 경계 */}
+            <rect x="20" y="20" width="360" height="260" fill="none" stroke="#3b82f6" strokeWidth="3" strokeDasharray="10,5" />
+            <text x="200" y="35" fill="#3b82f6" fontSize="16" textAnchor="middle" fontWeight="bold">SECTOR KE-14 BOUNDARY</text>
+
+            {/* 지형 요소 */}
+            <path
+              d="M 150 120 L 170 110 L 190 115 L 210 125 L 220 140 L 225 160 L 220 180 L 210 195 L 190 200 L 170 195 L 150 180 L 140 160 L 145 140 Z"
+              fill="rgba(34, 197, 94, 0.2)"
+              stroke="#22c55e"
+              strokeWidth="1"
+            />
+
+            {/* 항로 */}
+            <path d="M 50 150 L 350 150" stroke="#60a5fa" strokeWidth="2" strokeDasharray="5,5" />
+            <text x="200" y="145" fill="#60a5fa" fontSize="10" textAnchor="middle">AIRWAY A123</text>
+
+            <path d="M 200 50 L 200 250" stroke="#60a5fa" strokeWidth="2" strokeDasharray="5,5" />
+            <text x="205" y="150" fill="#60a5fa" fontSize="10">V456</text>
+
+            {/* 위험 구역 */}
+            <circle cx="300" cy="100" r="25" fill="rgba(239, 68, 68, 0.2)" stroke="#ef4444" strokeWidth="2" strokeDasharray="3,3" />
+            <text x="300" y="105" fill="#ef4444" fontSize="8" textAnchor="middle" fontWeight="bold">RESTRICTED</text>
+
+            {/* 공항/기지 */}
+            <rect x="95" y="195" width="10" height="10" fill="#22c55e" />
+            <text x="110" y="205" fill="#22c55e" fontSize="10">RKJK</text>
+
+            {/* 의료시설 */}
+            <circle cx="120" cy="240" r="5" fill="#f59e0b" />
+            <text x="130" y="245" fill="#f59e0b" fontSize="8">HOSPITAL</text>
+          </svg>
+
+          {/* 항적 표시 */}
+          <div className="absolute inset-0">
+            {sectorTracks.map(track => renderTrack(track))}
+          </div>
+
+          {/* 섹터 상태 표시 */}
+          <div className="absolute top-4 right-4 bg-gray-900/80 rounded-lg p-3 border border-blue-700">
+            <div className="text-sm text-blue-400 font-bold mb-2">KE-14 SECTOR STATUS</div>
+            <div className="text-xs text-green-400 space-y-1">
+              <div>Sector Size: <span className="text-green-300">50nm x 60nm</span></div>
+              <div>Altitude Band: <span className="text-green-300">FL100-FL450</span></div>
+              <div>Primary Radar: <span className="text-green-300">ONLINE 99%</span></div>
+              <div>Coverage: <span className="text-green-300">FULL</span></div>
+            </div>
+          </div>
+
+          {/* 조작원별 항적 할당 표시 */}
+          <div className="absolute bottom-4 left-4 bg-gray-900/80 rounded-lg p-3 border border-gray-700">
+            <div className="text-sm text-green-400 font-bold mb-2">TRACK ASSIGNMENTS</div>
+            <div className="text-xs space-y-1">
+              {operatorStations.filter(op => op.status === 'ACTIVE').map(op => {
+                const assignedTracks = sectorTracks.filter(track => track.controller === op.id);
+                return (
+                  <div key={op.id} className="flex justify-between">
+                    <span className="text-blue-400">{op.id}:</span>
+                    <span className="text-green-300">{assignedTracks.length} tracks</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* 우측: 상세 운영 정보 */}
+        <div className="w-96 bg-gray-800 border-l border-gray-700 p-4 space-y-4 overflow-y-auto">
+          {/* 선택된 운영진 상세 정보 */}
+          {selectedOperator && (
+            <div className="bg-gray-900 rounded-lg p-3 border-l-4 border-blue-500">
+              <h3 className="text-sm font-bold text-blue-400 mb-3 flex items-center">
+                <Users className="w-4 h-4 mr-2" />
+                OPERATOR DETAIL: {selectedOperator}
+              </h3>
+              {(() => {
+                const op = operatorStations.find(o => o.id === selectedOperator);
+                if (!op) return null;
+                const assignedTracks = sectorTracks.filter(t => t.controller === selectedOperator);
+                return (
+                  <div className="text-xs space-y-2">
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className="text-green-600">Name:</div>
+                      <div className="text-green-300">{op.operator}</div>
+                      <div className="text-green-600">Role:</div>
+                      <div className="text-green-300">{op.role}</div>
+                      <div className="text-green-600">Station:</div>
+                      <div className="text-green-300">{op.station}</div>
+                      <div className="text-green-600">Workload:</div>
+                      <div className={`font-bold ${
+                        op.workload === 'HIGH' ? 'text-red-400' :
+                        op.workload === 'MODERATE' ? 'text-yellow-400' : 'text-green-400'
+                      }`}>{op.workload}</div>
+                      <div className="text-green-600">Assigned Tracks:</div>
+                      <div className="text-blue-400">{assignedTracks.length}</div>
+                    </div>
+
+                    <div className="mt-3 pt-2 border-t border-gray-700">
+                      <div className="text-green-400 font-bold mb-1">Communication Channels:</div>
+                      <div className="flex flex-wrap gap-1">
+                        {op.commChannels.map(channel => (
+                          <span key={channel} className="bg-purple-900/50 text-purple-300 px-1 py-0.5 rounded text-[10px]">
+                            {channel}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+
+                    {assignedTracks.length > 0 && (
+                      <div className="mt-3 pt-2 border-t border-gray-700">
+                        <div className="text-green-400 font-bold mb-1">Assigned Aircraft:</div>
+                        {assignedTracks.map(track => (
+                          <div key={track.id} className="text-green-300 text-[10px] mb-1">
+                            {track.callsign} ({track.type}) - FL{Math.floor(track.altitude/100)}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
+            </div>
+          )}
+
+          {/* 통신 로그 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-purple-400 mb-3 flex items-center">
+              <MessageSquare className="w-4 h-4 mr-2" />
+              COMMUNICATION LOG
+            </h3>
+            <div className="text-xs space-y-2 max-h-40 overflow-y-auto">
+              {commLog.map((comm, index) => (
+                <div key={index} className={`p-2 rounded border-l-2 ${
+                  comm.priority === 'URGENT' ? 'border-red-500 bg-red-900/20' :
+                  comm.priority === 'PRIORITY' ? 'border-orange-500 bg-orange-900/20' :
+                  'border-blue-500 bg-blue-900/20'
+                }`}>
+                  <div className="flex justify-between items-start mb-1">
+                    <span className="text-green-300 font-bold">{comm.from} → {comm.to}</span>
+                    <span className="text-purple-400">{comm.channel}</span>
+                  </div>
+                  <div className="text-green-400">{comm.message}</div>
+                  <div className="text-gray-500 text-[10px] mt-1">
+                    {comm.time.toLocaleTimeString()} - {comm.priority}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 항적 상세 목록 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-green-400 mb-3 flex items-center">
+              <Crosshair className="w-4 h-4 mr-2" />
+              TRACK DETAILS
+            </h3>
+            <div className="text-xs space-y-2 max-h-64 overflow-y-auto">
+              {sectorTracks.map(track => (
+                <div
+                  key={track.id}
+                  className={`border rounded p-2 cursor-pointer transition-all ${
+                    selectedTrack?.id === track.id ? 'border-blue-500 bg-blue-900/20' :
+                    track.status === 'FRIENDLY' ? 'border-green-600' :
+                    track.status === 'UNKNOWN' ? 'border-yellow-600' : 'border-red-600'
+                  }`}
+                  onClick={() => setSelectedTrack(track)}
+                >
+                  <div className="flex justify-between items-center mb-1">
+                    <span className="text-green-300 font-bold">{track.callsign}</span>
+                    <span className={`px-1 py-0.5 rounded text-[10px] ${
+                      track.status === 'FRIENDLY' ? 'bg-green-900 text-green-300' :
+                      track.status === 'UNKNOWN' ? 'bg-yellow-900 text-yellow-300' :
+                      'bg-red-900 text-red-300'
+                    }`}>
+                      {track.status}
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-1 text-[10px]">
+                    <div>Type: {track.type}</div>
+                    <div>Mission: {track.mission}</div>
+                    <div>Alt: FL{Math.floor(track.altitude/100)}</div>
+                    <div>Speed: {track.speed}kt</div>
+                    <div>Hdg: {track.heading.toString().padStart(3, '0')}</div>
+                    <div>Fuel: {track.fuel}%</div>
+                    <div>Freq: {track.commsFreq}</div>
+                    <div>Sqwk: {track.squawk}</div>
+                  </div>
+                  <div className="text-blue-400 text-[10px] mt-1">
+                    Controller: {track.controller} | Last: {track.lastContact}
+                  </div>
+                  <div className="text-green-600 text-[10px]">
+                    Pilot: {track.pilot}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 섹터 운영 도구 */}
+          <div className="bg-gray-900 rounded-lg p-3">
+            <h3 className="text-sm font-bold text-yellow-400 mb-3 flex items-center">
+              <Settings className="w-4 h-4 mr-2" />
+              SECTOR TOOLS
+            </h3>
+            <div className="space-y-2">
+              <button className="w-full bg-blue-800 hover:bg-blue-700 text-white py-1 px-2 rounded text-xs">
+                HANDOFF TO ADJACENT
+              </button>
+              <button className="w-full bg-green-800 hover:bg-green-700 text-white py-1 px-2 rounded text-xs">
+                REQUEST HIGHER LEVEL
+              </button>
+              <button className="w-full bg-purple-800 hover:bg-purple-700 text-white py-1 px-2 rounded text-xs">
+                COORDINATE WITH TOWER
+              </button>
+              <button className="w-full bg-orange-800 hover:bg-orange-700 text-white py-1 px-2 rounded text-xs">
+                WEATHER UPDATE
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 하단 분류 표시 */}
+      <div className="bg-red-900 text-white text-center py-1 font-bold text-xs">
+        ★★ TOP SECRET // REL TO ROKAF // SECTOR KE-14 OPERATIONS ★★
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
사용자의 최종 피드백에 따라 프로젝트의 전체적인 개편을 완료했습니다.

- 루트 페이지를 DCRC 보고서 형식으로 개편하고, 모든 관련 샘플 페이지로의 링크를 포함시켰습니다.
- 사용자가 제공한 전체 코드로 `rokaf-mcrc-advanced-v2.tsx`와 `rokaf-sector-ke14-operations.tsx` 두 샘플 페이지를 완전히 복원했습니다.
- 복원 과정에서 발생한 다수의 빌드 오류(구문 오류, 타입 정의 누락, 타입 추론 오류 등)를 모두 수정하여 프로젝트를 빌드 가능한 상태로 만들었습니다.
- 개편으로 인해 더 이상 사용되지 않는 `/about` 페이지 관련 라우트와 파일들을 모두 삭제하여 코드베이스를 정리했습니다.